### PR TITLE
docs: align task state enum with TaskState source of truth

### DIFF
--- a/app/routes/mcp/tool_metadata_registry.py
+++ b/app/routes/mcp/tool_metadata_registry.py
@@ -1716,14 +1716,14 @@ def register_task_tools_metadata(
             "parameters": [
                 {"name": "plan_id", "type": "int", "description": "Plan to query tasks from", "required": True, "example": 1},
                 {"name": "ctx", "type": "Context", "description": "FastMCP Context (automatically injected)", "required": True},
-                {"name": "state", "type": "Optional[str]", "description": "Filter by task state (open, in_progress, blocked, done, cancelled)", "required": False, "default": None, "example": "open"},
+                {"name": "state", "type": "Optional[str]", "description": "Filter by task state (todo, doing, waiting, done, cancelled)", "required": False, "default": None, "example": "todo"},
                 {"name": "priority", "type": "Optional[str]", "description": "Filter by priority (P0, P1, P2, P3)", "required": False, "default": None, "example": "P1"},
                 {"name": "assigned_agent", "type": "Optional[str]", "description": "Filter by assigned agent", "required": False, "default": None, "example": "agent-123"},
             ],
             "returns": "Dictionary with tasks list and total_count",
             "examples": [
                 'execute_forgetful_tool("query_tasks", {"plan_id": 1})',
-                'execute_forgetful_tool("query_tasks", {"plan_id": 1, "state": "open", "priority": "P0"})',
+                'execute_forgetful_tool("query_tasks", {"plan_id": 1, "state": "todo", "priority": "P0"})',
             ],
             "tags": ["task", "query", "list"],
         },
@@ -1749,7 +1749,7 @@ def register_task_tools_metadata(
             "description": "Transition task to a new state with optimistic concurrency control",
             "parameters": [
                 {"name": "task_id", "type": "int", "description": "ID of the task to transition", "required": True, "example": 1},
-                {"name": "state", "type": "str", "description": "Target state (open, in_progress, blocked, done, cancelled)", "required": True, "example": "done"},
+                {"name": "state", "type": "str", "description": "Target state (todo, doing, waiting, done, cancelled)", "required": True, "example": "done"},
                 {"name": "version", "type": "int", "description": "Expected task version for optimistic locking", "required": True, "example": 2},
                 {"name": "ctx", "type": "Context", "description": "FastMCP Context (automatically injected)", "required": True},
             ],

--- a/docs/tool_reference.md
+++ b/docs/tool_reference.md
@@ -1504,7 +1504,26 @@ active_plans = execute_forgetful_tool(
 Manage tasks within plans, including acceptance criteria, dependencies, and agent assignment with optimistic locking.
 
 ### Task States
-Tasks follow a lifecycle: `pending` -> `in_progress` -> `completed` (or `blocked`, `cancelled`)
+
+Tasks follow a lifecycle defined by `TaskState` (see `app/models/plan_models.py`):
+
+- `todo` (default) — not started
+- `doing` — in progress
+- `waiting` — blocked / awaiting external input
+- `done` — completed
+- `cancelled` — will not be completed
+
+**Valid transitions** (enforced by `VALID_TASK_TRANSITIONS`):
+
+| From → To | Allowed |
+|---|---|
+| `todo` → | `doing`, `waiting`, `cancelled` |
+| `doing` → | `done`, `waiting`, `todo`, `cancelled` |
+| `waiting` → | `todo`, `doing`, `cancelled` |
+| `done` → | `todo` (reopen only) |
+| `cancelled` → | `todo` (reinstate only) |
+
+Any other transition is rejected by `transition_task` with a validation error.
 
 ### Task Priorities
 - `P0` - Critical
@@ -1605,12 +1624,12 @@ Query tasks within a plan with optional filtering.
 
 **Example:**
 ```python
-# Find all pending P0/P1 tasks assigned to an agent
+# Find all todo P0/P1 tasks assigned to an agent
 critical_tasks = execute_forgetful_tool(
     "query_tasks",
     {
         "plan_id": 5,
-        "state": "pending",
+        "state": "todo",
         "priority": "P1",
         "assigned_agent": "backend-agent"
     }
@@ -1659,24 +1678,24 @@ Transition a task to a new state. Uses optimistic locking to prevent conflicting
 
 **Example:**
 ```python
-# Move task to in_progress
+# Move task from todo to doing
 task = execute_forgetful_tool("get_task", {"task_id": 25})
 execute_forgetful_tool(
     "transition_task",
     {
         "task_id": 25,
-        "state": "in_progress",
+        "state": "doing",
         "version": task["version"]
     }
 )
 
-# Later, mark as completed
+# Later, mark as done
 task = execute_forgetful_tool("get_task", {"task_id": 25})
 execute_forgetful_tool(
     "transition_task",
     {
         "task_id": 25,
-        "state": "completed",
+        "state": "done",
         "version": task["version"]
     }
 )


### PR DESCRIPTION
## Context

While building on top of Forgetful 0.3.2, I noticed the documented task state enum drifted from the canonical `TaskState` defined in `app/models/plan_models.py`.

## Evidence

- `app/models/plan_models.py` defines `TaskState = {TODO, DOING, WAITING, DONE, CANCELLED}` with valid transitions in `VALID_TASK_TRANSITIONS`.
- `docs/concepts.md` already describes the correct state machine (`todo -> doing -> done`, plus `waiting` and `cancelled`).
- However:
  - `docs/tool_reference.md` under **Task States** claims the lifecycle is `pending -> in_progress -> completed (or blocked, cancelled)` — none of those strings correspond to any `TaskState` member.
  - `app/routes/mcp/tool_metadata_registry.py` parameter descriptions for `query_tasks` and `transition_task` mention `(open, in_progress, blocked, done, cancelled)` — also divergent.
- Runtime DB inspection on 0.3.2 confirms only `todo / doing / waiting / done` are present.

## Changes

- `docs/tool_reference.md`: rewrite the **Task States** section with the 5 canonical values and include the transition matrix from `VALID_TASK_TRANSITIONS`. Fix `query_tasks` and `transition_task` examples to use `todo`, `doing`, `done`.
- `app/routes/mcp/tool_metadata_registry.py`: correct the `state` parameter description + example strings for `query_tasks` and `transition_task`.

## Non-goals

- No behavior change. No enum renamed. No DB schema change.
- Tests already use the correct values and remain green.

## Verification

Searched the tree for remaining `pending`/`in_progress`/`completed`/`open`/`blocked` strings in contexts that refer to task state:

- `docs/concepts.md` — already correct (`todo -> doing -> done`).
- `docs/api_reference.md` — `blocked: false` refers to a `criterion`, not a task state. Untouched.
- Tests: no reference to the wrong strings.

Happy to split if you prefer separate PRs for docs vs registry description.