### PR TITLE
feat(graph): make /api/v1/graph node cap configurable via MAX_GRAPH_LIMIT (refs #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ For deep dive on search architecture (dense → sparse → RRF → cross-encoder
 - `EMBEDDING_MODEL` – Embedding model (default: `BAAI/bge-small-en-v1.5`)
 - `MEMORY_NUM_AUTO_LINK` – Auto-link count (default: `3`, set `0` to disable)
 - `SERVER_PORT` – HTTP server port (default: `8020`)
+- `MAX_GRAPH_LIMIT` – Upper bound for `/api/v1/graph` `?limit` and `/api/v1/graph/subgraph` `?max_nodes` (default: `2000`)
 
 For all 40+ environment variables with detailed explanations, see [Configuration Guide](docs/configuration.md).
 

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -177,6 +177,12 @@ class Settings(BaseSettings):
     # SSE Streaming Configuration
     SSE_MAX_QUEUE_SIZE: int = 1000               # Max events per SSE subscriber queue (backpressure)
 
+    # Graph Visualization Configuration
+    # Safety cap for the /api/v1/graph and /api/v1/graph/subgraph endpoints.
+    # Prevents clients from requesting an unbounded number of nodes in a single
+    # response while staying configurable for larger graphs (see issue #23).
+    MAX_GRAPH_LIMIT: int = 2000                  # Upper bound for ?limit and ?max_nodes query params
+
     # Search Configuration
     EMBEDDING_PROVIDER: str = "FastEmbed" # FastEmbed | Azure | Google | OpenAI | Ollama
     EMBEDDING_MODEL: str = "BAAI/bge-small-en-v1.5"

--- a/app/routes/api/graph.py
+++ b/app/routes/api/graph.py
@@ -10,6 +10,7 @@ from fastmcp import FastMCP
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from app.config.settings import settings
 from app.exceptions import NotFoundError
 from app.middleware.auth import get_user_from_request
 
@@ -32,7 +33,8 @@ def register(mcp: FastMCP):
             node_types: Comma-separated list of node types to include
                        (default: memory,entity,project,document,code_artifact)
             include_entities: Legacy param, deprecated in favor of node_types
-            limit: Max memories to include (default 100, max 500)
+            limit: Max memories to include (default 100, max configurable via
+                   MAX_GRAPH_LIMIT setting / env var, defaults to 2000)
             offset: Number of memories to skip for pagination (default 0)
             sort_by: Sort field - created_at, updated_at, importance (default created_at)
             sort_order: Sort direction - asc, desc (default desc)
@@ -74,9 +76,9 @@ def register(mcp: FastMCP):
             include_documents = True
             include_code_artifacts = True
 
-        # Validate limit parameter
+        # Validate limit parameter (cap at configurable MAX_GRAPH_LIMIT, see issue #23)
         try:
-            limit = min(int(limit_str), 500)
+            limit = min(int(limit_str), settings.MAX_GRAPH_LIMIT)
         except ValueError:
             return JSONResponse(
                 {"error": f"Invalid limit: {limit_str}. Must be an integer."},
@@ -659,7 +661,8 @@ def register(mcp: FastMCP):
             node_id: Center node in format "memory_{id}", "entity_{id}", "project_{id}", "document_{id}", or "code_artifact_{id}" (required)
             depth: Traversal depth 1-3 (default 2)
             node_types: Comma-separated list of types to include (default: "memory,entity,project,document,code_artifact")
-            max_nodes: Safety limit (default 200, max 500)
+            max_nodes: Safety limit (default 200, max configurable via
+                       MAX_GRAPH_LIMIT setting / env var, defaults to 2000)
 
         Returns:
             nodes: List with depth field on each node

--- a/app/services/graph_service.py
+++ b/app/services/graph_service.py
@@ -10,6 +10,7 @@ from typing import Any, Protocol
 from uuid import UUID
 
 from app.config.logging_config import logging
+from app.config.settings import settings
 from app.exceptions import NotFoundError
 from app.models.graph_models import (
     SubgraphEdge,
@@ -133,7 +134,8 @@ class GraphService:
             depth: Traversal depth 1-3 (default 2, clamped)
             node_types: Filter to any combination of ['memory', 'entity', 'project',
                        'document', 'code_artifact'] (default: all 5 types)
-            max_nodes: Safety limit (default 200, max 500)
+            max_nodes: Safety limit (default 200, max configurable via
+                       MAX_GRAPH_LIMIT setting / env var, defaults to 2000)
 
         Returns:
             SubgraphResponse with nodes, edges, and metadata
@@ -148,9 +150,9 @@ class GraphService:
         # Validate center node exists
         await self._validate_center_node(user_id, center_type, center_id)
 
-        # Clamp parameters
+        # Clamp parameters (max_nodes cap is configurable via MAX_GRAPH_LIMIT, see issue #23)
         depth = max(1, min(depth, 3))
-        max_nodes = max(1, min(max_nodes, 500))
+        max_nodes = max(1, min(max_nodes, settings.MAX_GRAPH_LIMIT))
 
         # Determine which node types to include (default: all types)
         if node_types is None:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -225,3 +225,4 @@ ACTIVITY_TRACK_READS=false  # Track read operations (get_memory, query_memory)
 # SSE Streaming Configuration
 # Real-time activity event streaming via Server-Sent Events at /api/v1/activity/stream
 SSE_MAX_QUEUE_SIZE=1000  # Max events per subscriber queue (backpressure). Increase for bulk operations.
+MAX_GRAPH_LIMIT=2000  # Max nodes returned by graph endpoints. Increase for large graph visualizations.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -753,6 +753,16 @@ Activity tracking provides an audit log of all entity lifecycle events (created,
 - **Note**: Increase for high-throughput scenarios where bulk operations are common
 - **Example**: `SSE_MAX_QUEUE_SIZE=2000`
 
+### Graph Visualization Configuration
+
+#### `MAX_GRAPH_LIMIT`
+- **Default**: `2000`
+- **Description**: Upper bound for the `?limit` query parameter on `/api/v1/graph` and the `?max_nodes` query parameter on `/api/v1/graph/subgraph` (enforced in `GraphService.get_subgraph`)
+- **Purpose**: Safety cap that prevents clients from requesting an unbounded number of nodes in a single response, while staying configurable for larger knowledge graphs (see issue #23)
+- **Behavior**: Any client-provided value above this cap is silently clamped; values at or below are passed through unchanged. A value of `0` is clamped up to `1` for `/graph/subgraph`.
+- **Note**: Before this setting was introduced the cap was hardcoded to `500`, which excluded older memories from the full graph visualization on larger knowledge bases.
+- **Example**: `MAX_GRAPH_LIMIT=5000`
+
 ### Example Configuration
 
 ```bash

--- a/tests/e2e/test_graph_e2e.py
+++ b/tests/e2e/test_graph_e2e.py
@@ -9,6 +9,8 @@ Requires:
 """
 import pytest
 
+from app.config.settings import settings
+
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 
@@ -563,6 +565,17 @@ async def test_graph_pagination_metadata(http_client):
     assert meta["limit"] == 2
     assert meta["total_memory_count"] >= 5
     assert meta["has_more"] is True  # We have more than 2 memories
+
+
+@pytest.mark.e2e
+async def test_graph_respects_max_graph_limit_setting(http_client, monkeypatch):
+    """GET /api/v1/graph clamps the requested limit to settings.MAX_GRAPH_LIMIT."""
+    monkeypatch.setattr(settings, "MAX_GRAPH_LIMIT", 50)
+
+    response = await http_client.get("/api/v1/graph?limit=99999")
+    assert response.status_code == 200
+    meta = response.json()["meta"]
+    assert meta["limit"] == 50
 
 
 @pytest.mark.e2e

--- a/tests/e2e_sqlite/test_api_graph_limit_settings.py
+++ b/tests/e2e_sqlite/test_api_graph_limit_settings.py
@@ -1,0 +1,56 @@
+"""Tests for the configurable MAX_GRAPH_LIMIT setting on /api/v1/graph (issue #23).
+
+Replaces the legacy hardcoded 500-node cap with settings.MAX_GRAPH_LIMIT
+(default 2000). Verified against the in-memory SQLite e2e fixture so the
+tests run by default (no Docker required).
+
+Covers three scenarios:
+    1. Default setting value is 2000 and is echoed by the route.
+    2. Monkeypatching the setting to a small value is honored.
+    3. A client-provided limit below the cap is preserved as-is.
+"""
+import pytest
+
+from app.config.settings import settings
+
+
+class TestGraphMaxGraphLimitSetting:
+    """Verify /api/v1/graph honors settings.MAX_GRAPH_LIMIT instead of a hardcoded 500 cap."""
+
+    @pytest.mark.asyncio
+    async def test_default_max_graph_limit_is_2000(self, http_client):
+        """MAX_GRAPH_LIMIT default value is 2000, replacing the legacy 500 cap."""
+        assert settings.MAX_GRAPH_LIMIT == 2000, (
+            "Default MAX_GRAPH_LIMIT changed unexpectedly; was 500 before issue #23"
+        )
+
+        response = await http_client.get("/api/v1/graph?limit=99999")
+        assert response.status_code == 200
+        meta = response.json()["meta"]
+        assert meta["limit"] == 2000, (
+            f"Expected meta.limit=2000 (MAX_GRAPH_LIMIT default), got {meta['limit']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_setting_override_is_respected(self, http_client, monkeypatch):
+        """Overriding settings.MAX_GRAPH_LIMIT is honored by the route."""
+        monkeypatch.setattr(settings, "MAX_GRAPH_LIMIT", 50)
+
+        response = await http_client.get("/api/v1/graph?limit=9999")
+        assert response.status_code == 200
+        meta = response.json()["meta"]
+        assert meta["limit"] == 50, (
+            f"Expected meta.limit=50 after monkeypatch, got {meta['limit']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_user_value_below_cap_is_preserved(self, http_client, monkeypatch):
+        """When the client ?limit is below MAX_GRAPH_LIMIT, the client value wins."""
+        monkeypatch.setattr(settings, "MAX_GRAPH_LIMIT", 50)
+
+        response = await http_client.get("/api/v1/graph?limit=10")
+        assert response.status_code == 200
+        meta = response.json()["meta"]
+        assert meta["limit"] == 10, (
+            f"Expected meta.limit=10 (user value, below cap), got {meta['limit']}"
+        )


### PR DESCRIPTION
## Summary

Replaces the hardcoded 500-node cap on `/api/v1/graph` and `/api/v1/graph/subgraph` with a configurable `settings.MAX_GRAPH_LIMIT` (default `2000`).

Issue #23 introduced pagination (`offset`, `sort_by`, `sort_order`, `total_memory_count`, `has_more`) but kept the `min(limit, 500)` clamp in `app/routes/api/graph.py`, which still excludes older memories from full-graph visualizations once a user has more than 500 memories.

## Motivation

- On a real-world knowledge base (~530 memories today, target 1000+), the current cap silently truncates the graph at 500 nodes even when the client asks for more.
- Frontend graph visualizers (e.g. `forgetful-viz`, custom dashboards) already implement their own paging / filtering, so the useful invariant at the API level is a **safety cap**, not a fixed product limit.
- Keeping a cap is still valuable to prevent unbounded responses — but it should be an operator decision, not a library constant.

Before:
```python
# app/routes/api/graph.py
limit = min(int(limit_str), 500)
```
```python
# app/services/graph_service.py (get_subgraph)
max_nodes = max(1, min(max_nodes, 500))
```

After:
```python
limit = min(int(limit_str), settings.MAX_GRAPH_LIMIT)
max_nodes = max(1, min(max_nodes, settings.MAX_GRAPH_LIMIT))
```

## Changes

- `app/config/settings.py` — new `MAX_GRAPH_LIMIT: int = 2000` field under a dedicated **Graph Visualization Configuration** block, matching the existing pydantic-settings convention (uppercase field names, inline defaults, no `Field(...)`).
- `app/routes/api/graph.py` — `/api/v1/graph` clamps `?limit` against `settings.MAX_GRAPH_LIMIT`. Docstrings for both `/api/v1/graph` and `/api/v1/graph/subgraph` mention the new env var.
- `app/services/graph_service.py` — `GraphService.get_subgraph` clamps `max_nodes` against `settings.MAX_GRAPH_LIMIT`, so the subgraph endpoint inherits the same knob without duplicating the cap in the route.
- `tests/e2e_sqlite/test_api_graph_limit_settings.py` — three new tests running against the in-process SQLite fixture (no Docker required):
  - `test_default_max_graph_limit_is_2000` — the new default is echoed in `meta.limit` when client requests `?limit=99999`.
  - `test_setting_override_is_respected` — `monkeypatch.setattr(settings, "MAX_GRAPH_LIMIT", 50)` + `?limit=9999` returns `meta.limit == 50`.
  - `test_user_value_below_cap_is_preserved` — user-provided value below the cap is preserved as-is.
- `README.md` — adds `MAX_GRAPH_LIMIT` to the **Key Settings (Optional)** list.
- `docs/configuration.md` — new **Graph Visualization Configuration** section with default, purpose, behavior, note on the previous 500 cap, and an example.

## Backward compatibility

Fully backward compatible:
- Default cap (2000) is ≥ previous cap (500), so existing clients see strictly more data (up to the number of memories they own) — no existing test breaks.
- Operators who want the previous behavior can simply set `MAX_GRAPH_LIMIT=500`.
- Pagination semantics are unchanged (`offset`, `sort_by`, `sort_order`, `total_memory_count`, `has_more` all behave exactly as in #23).

## Test plan

- [x] New tests pass locally against the SQLite e2e fixture (reranking disabled): `uv run pytest tests/e2e_sqlite/test_api_graph_limit_settings.py -v` → **3/3 passed**.
- [x] Full `tests/e2e_sqlite/test_api_graph.py` still green: **61/61 passed**.
- [ ] CI to run the Postgres e2e suite on this branch.

## References

- Closes the regression of #23 (cap not lifted despite pagination landing).
- Does **not** touch the existing `offset`/`sort_by`/`has_more` behavior from #23 — this PR is strictly the configurable-cap piece.
