### PR TITLE
fix(skills): accept unquoted colons in import_skill YAML frontmatter

### DIFF
--- a/app/services/skill_service.py
+++ b/app/services/skill_service.py
@@ -6,6 +6,7 @@ This service implements functionality for managing skills:
     - Import/export in Agent Skills markdown format
     - Project association
 """
+import re
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -38,6 +39,34 @@ if TYPE_CHECKING:
     from app.events import EventBus
 
 logger = logging.getLogger(__name__)
+
+
+def _quote_unquoted_frontmatter_scalars(raw: str) -> str:
+    """Quote scalar frontmatter values that contain unescaped colons."""
+    quoted_lines: list[str] = []
+    for line in raw.splitlines():
+        match = re.match(r"^([A-Za-z0-9_-]+):\s+(.*)$", line)
+        if not match:
+            quoted_lines.append(line)
+            continue
+
+        key, value = match.group(1), match.group(2)
+        if not value:
+            quoted_lines.append(line)
+            continue
+
+        stripped = value.lstrip()
+        if stripped.startswith(("[", "{", "|", ">", '"', "'")):
+            quoted_lines.append(line)
+            continue
+
+        if ":" in value:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            quoted_lines.append(f'{key}: "{escaped}"')
+        else:
+            quoted_lines.append(line)
+
+    return "\n".join(quoted_lines)
 
 
 class SkillService:
@@ -491,7 +520,7 @@ class SkillService:
         frontmatter_raw = parts[1].strip()
         body = parts[2].strip()
 
-        frontmatter = yaml.safe_load(frontmatter_raw)
+        frontmatter = yaml.safe_load(_quote_unquoted_frontmatter_scalars(frontmatter_raw))
         if not isinstance(frontmatter, dict):
             raise ValueError("Invalid YAML frontmatter: expected a mapping")
 

--- a/docs/tool_reference.md
+++ b/docs/tool_reference.md
@@ -952,6 +952,8 @@ Import a skill from Agent Skills markdown format (SKILL.md).
 - `project_id` (optional): Project association
 - `importance` (optional): Importance level (default: 7)
 
+Scalar frontmatter values may contain unquoted colons (for example `Keywords:` in a description); the importer quotes them before parsing.
+
 **Returns:**
 - Created Skill with generated ID
 

--- a/tests/e2e_sqlite/test_skill_tools_sqlite.py
+++ b/tests/e2e_sqlite/test_skill_tools_sqlite.py
@@ -256,6 +256,30 @@ allowed-tools:
 
 
 @pytest.mark.asyncio
+async def test_import_skill_unquoted_colon_in_description(mcp_client):
+    """Import skill with unquoted colon in description scalar (Scott #50 repro)."""
+    skill_md = """---
+name: keyword-skill
+description: Use when X. Keywords: foo, bar.
+---
+
+# Keyword Skill
+
+Body content.
+"""
+    result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "import_skill",
+        "arguments": {
+            "skill_md_content": skill_md,
+            "importance": 8,
+        },
+    })
+    assert result.data is not None
+    assert result.data["name"] == "keyword-skill"
+    assert result.data["description"] == "Use when X. Keywords: foo, bar."
+
+
+@pytest.mark.asyncio
 async def test_export_skill(mcp_client):
     """Test exporting a skill to SKILL.md format"""
     create_result = await mcp_client.call_tool("execute_forgetful_tool", {

--- a/tests/integration/test_skill_frontmatter_quoting.py
+++ b/tests/integration/test_skill_frontmatter_quoting.py
@@ -1,0 +1,50 @@
+"""Unit tests for skill frontmatter scalar quoting helper."""
+import yaml
+
+from app.services.skill_service import _quote_unquoted_frontmatter_scalars
+
+
+def test_quotes_unquoted_scalar_with_colon():
+    raw = "description: Use when X. Keywords: foo, bar."
+    quoted = _quote_unquoted_frontmatter_scalars(raw)
+    parsed = yaml.safe_load(quoted)
+    assert parsed["description"] == "Use when X. Keywords: foo, bar."
+
+
+def test_leaves_already_quoted_scalar_unchanged():
+    raw = 'description: "Use when X. Keywords: foo, bar."'
+    assert _quote_unquoted_frontmatter_scalars(raw) == raw
+
+
+def test_escapes_internal_double_quotes():
+    raw = 'description: Say "hello" here: done.'
+    quoted = _quote_unquoted_frontmatter_scalars(raw)
+    parsed = yaml.safe_load(quoted)
+    assert parsed["description"] == 'Say "hello" here: done.'
+
+
+def test_skips_block_scalar_starter():
+    raw = "summary: |\n  line one: value\n  line two"
+    assert _quote_unquoted_frontmatter_scalars(raw) == raw
+
+
+def test_skips_flow_sequence_starter():
+    raw = "allowed-tools:\n  - Read"
+    assert _quote_unquoted_frontmatter_scalars(raw) == raw
+
+
+def test_skips_bracket_scalar_starter():
+    raw = "tags: [one, two: three]"
+    assert _quote_unquoted_frontmatter_scalars(raw) == raw
+
+
+def test_preserves_indented_nested_mapping_lines():
+    raw = (
+        "description: Use when X. Keywords: foo, bar.\n"
+        "metadata:\n"
+        "  author: scottesh"
+    )
+    quoted = _quote_unquoted_frontmatter_scalars(raw)
+    parsed = yaml.safe_load(quoted)
+    assert parsed["description"] == "Use when X. Keywords: foo, bar."
+    assert parsed["metadata"] == {"author": "scottesh"}

--- a/tests/integration/test_skill_service.py
+++ b/tests/integration/test_skill_service.py
@@ -294,6 +294,81 @@ metadata:
 
 
 @pytest.mark.asyncio
+async def test_import_skill_unquoted_colon_in_description(test_skill_service):
+    user_id = uuid4()
+
+    skill_md = """---
+name: keyword-skill
+description: Use when X. Keywords: foo, bar.
+---
+
+# Keyword Skill
+
+Body content.
+"""
+
+    skill = await test_skill_service.import_skill(
+        user_id, skill_md, project_id=1, importance=8,
+    )
+
+    assert skill.name == "keyword-skill"
+    assert skill.description == "Use when X. Keywords: foo, bar."
+
+
+@pytest.mark.asyncio
+async def test_import_skill_quoted_colon_in_description(test_skill_service):
+    user_id = uuid4()
+
+    skill_md = """---
+name: quoted-keyword-skill
+description: "Use when X. Keywords: foo, bar."
+---
+
+# Keyword Skill
+
+Body content.
+"""
+
+    skill = await test_skill_service.import_skill(user_id, skill_md)
+
+    assert skill.description == "Use when X. Keywords: foo, bar."
+
+
+@pytest.mark.asyncio
+async def test_import_skill_nested_metadata_with_colon_description(test_skill_service):
+    user_id = uuid4()
+
+    skill_md = """---
+name: nested-colon-skill
+description: Use when reviewing. Keywords: foo, bar.
+license: MIT
+allowed-tools:
+  - Read
+metadata:
+  author: scottesh
+---
+
+# Nested Skill
+
+Steps here.
+"""
+
+    skill = await test_skill_service.import_skill(user_id, skill_md)
+
+    assert skill.description == "Use when reviewing. Keywords: foo, bar."
+    assert skill.allowed_tools == ["Read"]
+    assert skill.metadata == {"author": "scottesh"}
+
+
+@pytest.mark.asyncio
+async def test_import_skill_missing_frontmatter_raises(test_skill_service):
+    user_id = uuid4()
+
+    with pytest.raises(ValueError, match="expected YAML frontmatter"):
+        await test_skill_service.import_skill(user_id, "# No frontmatter\n")
+
+
+@pytest.mark.asyncio
 async def test_export_skill(test_skill_service):
     user_id = uuid4()
 


### PR DESCRIPTION
Fixes #50

import_skill currently dies on a description like:

    description: Use when X. Keywords: foo, bar.

yaml.safe_load treats the second colon as a mapping. That's the usual Claude Code Keywords: line.

I quote those unquoted scalars before parsing. Nested maps and lists (metadata, allowed-tools) are left alone. Values that are already quoted stay as they are.

I added integration tests, an MCP sqlite e2e import, and a small unit test on the quoting helper.
