### PR TITLE
fix: raise NotFoundError from get_project, get_plan, and get_task

### DIFF
--- a/app/routes/api/plans.py
+++ b/app/routes/api/plans.py
@@ -57,8 +57,9 @@ def register(mcp: FastMCP):
             return JSONResponse({"error": str(e)}, status_code=401)
 
         plan_id = int(request.path_params["plan_id"])
-        plan = await mcp.plan_service.get_plan(user_id=user.id, plan_id=plan_id)
-        if not plan:
+        try:
+            plan = await mcp.plan_service.get_plan(user_id=user.id, plan_id=plan_id)
+        except NotFoundError:
             return JSONResponse({"error": "Plan not found"}, status_code=404)
         return JSONResponse(plan.model_dump(mode="json"))
 

--- a/app/routes/api/projects.py
+++ b/app/routes/api/projects.py
@@ -73,12 +73,12 @@ def register(mcp: FastMCP):
 
         project_id = int(request.path_params["project_id"])
 
-        project = await mcp.project_service.get_project(
-            user_id=user.id,
-            project_id=project_id,
-        )
-
-        if not project:
+        try:
+            project = await mcp.project_service.get_project(
+                user_id=user.id,
+                project_id=project_id,
+            )
+        except NotFoundError:
             return JSONResponse({"error": "Project not found"}, status_code=404)
 
         return JSONResponse(project.model_dump(mode="json"))

--- a/app/routes/api/tasks.py
+++ b/app/routes/api/tasks.py
@@ -70,8 +70,9 @@ def register(mcp: FastMCP):
             return JSONResponse({"error": str(e)}, status_code=401)
 
         task_id = int(request.path_params["task_id"])
-        task = await mcp.task_service.get_task(user_id=user.id, task_id=task_id)
-        if not task:
+        try:
+            task = await mcp.task_service.get_task(user_id=user.id, task_id=task_id)
+        except NotFoundError:
             return JSONResponse({"error": "Task not found"}, status_code=404)
         return JSONResponse(task.model_dump(mode="json"))
 

--- a/app/services/plan_service.py
+++ b/app/services/plan_service.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from app.config.logging_config import logging
 from app.config.settings import settings
-from app.exceptions import InvalidStateTransitionError
+from app.exceptions import InvalidStateTransitionError, NotFoundError
 from app.models.activity_models import (
     ActionType,
     ActivityEvent,
@@ -81,7 +81,7 @@ class PlanService:
         )
         return plan
 
-    async def get_plan(self, user_id: UUID, plan_id: int) -> Plan | None:
+    async def get_plan(self, user_id: UUID, plan_id: int) -> Plan:
         logger.info("getting plan", extra={"user_id": str(user_id), "plan_id": plan_id})
         plan = await self.plan_repo.get_plan_by_id(user_id=user_id, plan_id=plan_id)
         if plan:
@@ -94,9 +94,9 @@ class PlanService:
                     action=ActionType.READ,
                     snapshot=plan.model_dump(mode="json"),
                 )
-        else:
-            logger.info("plan not found", extra={"plan_id": plan_id})
-        return plan
+            return plan
+        logger.info("plan not found", extra={"plan_id": plan_id})
+        raise NotFoundError(f"Plan with id {plan_id} not found")
 
     async def list_plans(
         self,

--- a/app/services/project_service.py
+++ b/app/services/project_service.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from app.config.logging_config import logging
 from app.config.settings import settings
+from app.exceptions import NotFoundError
 from app.models.activity_models import (
     ActionType,
     ActivityEvent,
@@ -155,7 +156,7 @@ class ProjectService:
 
         return projects
 
-    async def get_project(self, user_id: UUID, project_id: int) -> Project | None:
+    async def get_project(self, user_id: UUID, project_id: int) -> Project:
         """Get single project by ID
 
         Retrieves complete project details including description, notes,
@@ -166,7 +167,10 @@ class ProjectService:
             project_id: Project ID to retrieve
 
         Returns:
-            Project if found, None otherwise
+            Project if found
+
+        Raises:
+            NotFoundError: If project does not exist or is not visible to user
         """
         logger.info(
             "getting project", extra={"user_id": str(user_id), "project_id": project_id},
@@ -191,13 +195,13 @@ class ProjectService:
                     action=ActionType.READ,
                     snapshot=project.model_dump(mode="json"),
                 )
-        else:
-            logger.info(
-                "project not found",
-                extra={"project_id": project_id, "user_id": str(user_id)},
-            )
+            return project
 
-        return project
+        logger.info(
+            "project not found",
+            extra={"project_id": project_id, "user_id": str(user_id)},
+        )
+        raise NotFoundError(f"Project with id {project_id} not found")
 
     async def create_project(
         self, user_id: UUID, project_data: ProjectCreate,

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -87,8 +87,6 @@ class TaskService:
 
         # Validate plan exists and is not COMPLETED/ARCHIVED
         plan = await self.plan_service.get_plan(user_id=user_id, plan_id=task_data.plan_id)
-        if not plan:
-            raise NotFoundError(f"Plan with id {task_data.plan_id} not found")
 
         plan_status = PlanStatus(plan.status)
         if plan_status in (PlanStatus.COMPLETED, PlanStatus.ARCHIVED):
@@ -129,14 +127,14 @@ class TaskService:
         )
         return task
 
-    async def get_task(self, user_id: UUID, task_id: int) -> Task | None:
+    async def get_task(self, user_id: UUID, task_id: int) -> Task:
         logger.info("getting task", extra={"user_id": str(user_id), "task_id": task_id})
         task = await self.task_repo.get_task_by_id(user_id=user_id, task_id=task_id)
         if task:
             logger.info("task retrieved", extra={"task_id": task_id})
-        else:
-            logger.info("task not found", extra={"task_id": task_id})
-        return task
+            return task
+        logger.info("task not found", extra={"task_id": task_id})
+        raise NotFoundError(f"Task with id {task_id} not found")
 
     async def list_tasks(
         self,
@@ -498,8 +496,11 @@ class TaskService:
         has_done = any(TaskState(t.state) == TaskState.DONE for t in tasks)
 
         if all_terminal and has_done:
-            plan = await self.plan_service.get_plan(user_id=user_id, plan_id=plan_id)
-            if plan and PlanStatus(plan.status) == PlanStatus.ACTIVE:
+            try:
+                plan = await self.plan_service.get_plan(user_id=user_id, plan_id=plan_id)
+            except NotFoundError:
+                return
+            if PlanStatus(plan.status) == PlanStatus.ACTIVE:
                 logger.info("auto-completing plan", extra={"plan_id": plan_id})
                 await self.plan_service.update_plan(
                     user_id=user_id,

--- a/docs/tool_reference.md
+++ b/docs/tool_reference.md
@@ -472,6 +472,9 @@ Retrieve complete project details by ID.
 **Returns:**
 - Complete project object
 
+**Errors:**
+- Raises an error (not `null`) when `project_id` does not exist or is not visible to the caller
+
 **Example:**
 ```python
 project = execute_forgetful_tool("get_project", {"project_id": 22})
@@ -1510,6 +1513,9 @@ Retrieve complete plan details by ID.
 **Returns:**
 - Complete plan object with all fields
 
+**Errors:**
+- Raises an error (not `null`) when `plan_id` does not exist or is not visible to the caller
+
 **Example:**
 ```python
 plan = execute_forgetful_tool("get_plan", {"plan_id": 5})
@@ -1640,6 +1646,9 @@ Get task with its acceptance criteria and dependency IDs.
 
 **Returns:**
 - Complete task object including criteria and dependency_ids
+
+**Errors:**
+- Raises an error (not `null`) when `task_id` does not exist or is not visible to the caller
 
 **Example:**
 ```python

--- a/tests/e2e/test_project_tools_e2e.py
+++ b/tests/e2e/test_project_tools_e2e.py
@@ -294,20 +294,11 @@ async def test_project_persistence_e2e(mcp_client):
 @pytest.mark.e2e
 async def test_get_project_invalid_id_e2e(mcp_client):
     """Test error handling when getting non-existent project"""
-    with pytest.raises((ToolError, Exception)) as exc_info:
-        result = await mcp_client.call_tool(
+    with pytest.raises(ToolError, match="not found"):
+        await mcp_client.call_tool(
             "execute_forgetful_tool",
             {"tool_name": "get_project", "arguments": {"project_id": 999999}},
         )
-        # If no exception, the call succeeded but should return error indication
-        if result.data is None or (hasattr(result, "is_error") and result.is_error):
-            raise ValueError("Project not found")
-    error_message = str(exc_info.value).lower()
-    assert (
-        "not found" in error_message
-        or "validation_error" in error_message
-        or "project not found" in error_message
-    )
 
 
 @pytest.mark.e2e

--- a/tests/e2e_sqlite/test_api_plans.py
+++ b/tests/e2e_sqlite/test_api_plans.py
@@ -1,0 +1,13 @@
+"""E2E tests for Plan REST API endpoints (SQLite)."""
+import pytest
+
+
+class TestPlanAPICrud:
+    """Test Plan GET operations."""
+
+    @pytest.mark.asyncio
+    async def test_get_plan_not_found(self, http_client):
+        """GET /api/v1/plans/{id} returns 404 for missing plan."""
+        response = await http_client.get("/api/v1/plans/99999")
+        assert response.status_code == 404
+        assert response.json()["error"] == "Plan not found"

--- a/tests/e2e_sqlite/test_api_tasks.py
+++ b/tests/e2e_sqlite/test_api_tasks.py
@@ -1,0 +1,13 @@
+"""E2E tests for Task REST API endpoints (SQLite)."""
+import pytest
+
+
+class TestTaskAPICrud:
+    """Test Task GET operations."""
+
+    @pytest.mark.asyncio
+    async def test_get_task_not_found(self, http_client):
+        """GET /api/v1/tasks/{id} returns 404 for missing task."""
+        response = await http_client.get("/api/v1/tasks/99999")
+        assert response.status_code == 404
+        assert response.json()["error"] == "Task not found"

--- a/tests/e2e_sqlite/test_plan_tools_sqlite.py
+++ b/tests/e2e_sqlite/test_plan_tools_sqlite.py
@@ -283,6 +283,16 @@ async def test_list_plans_filter_by_status_e2e(mcp_client):
 
 
 @pytest.mark.asyncio
+async def test_get_plan_invalid_id_e2e(mcp_client):
+    """Test error handling when getting non-existent plan"""
+    with pytest.raises(ToolError, match="not found"):
+        await mcp_client.call_tool(
+            "execute_forgetful_tool",
+            {"tool_name": "get_plan", "arguments": {"plan_id": 999999}},
+        )
+
+
+@pytest.mark.asyncio
 async def test_plan_discover_tools_e2e(mcp_client):
     """Test that plan tools appear in discover_forgetful_tools"""
     result = await mcp_client.call_tool(

--- a/tests/e2e_sqlite/test_project_tools_sqlite.py
+++ b/tests/e2e_sqlite/test_project_tools_sqlite.py
@@ -289,20 +289,11 @@ async def test_project_persistence_e2e(mcp_client):
 @pytest.mark.asyncio
 async def test_get_project_invalid_id_e2e(mcp_client):
     """Test error handling when getting non-existent project"""
-    with pytest.raises((ToolError, Exception)) as exc_info:
-        result = await mcp_client.call_tool(
+    with pytest.raises(ToolError, match="not found"):
+        await mcp_client.call_tool(
             "execute_forgetful_tool",
             {"tool_name": "get_project", "arguments": {"project_id": 999999}},
         )
-        # If no exception, the call succeeded but should return error indication
-        if result.data is None or (hasattr(result, "is_error") and result.is_error):
-            raise ValueError("Project not found")
-    error_message = str(exc_info.value).lower()
-    assert (
-        "not found" in error_message
-        or "validation_error" in error_message
-        or "project not found" in error_message
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/e2e_sqlite/test_task_tools_sqlite.py
+++ b/tests/e2e_sqlite/test_task_tools_sqlite.py
@@ -739,6 +739,16 @@ async def test_create_task_with_inline_criteria_e2e(mcp_client):
 # ---- Discover Task Tools ----
 
 @pytest.mark.asyncio
+async def test_get_task_invalid_id_e2e(mcp_client):
+    """Test error handling when getting non-existent task"""
+    with pytest.raises(ToolError, match="not found"):
+        await mcp_client.call_tool(
+            "execute_forgetful_tool",
+            {"tool_name": "get_task", "arguments": {"task_id": 999999}},
+        )
+
+
+@pytest.mark.asyncio
 async def test_task_discover_tools_e2e(mcp_client):
     """Test that task tools appear in discover_forgetful_tools"""
     result = await mcp_client.call_tool(

--- a/tests/integration/test_plan_service.py
+++ b/tests/integration/test_plan_service.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pytest
 
+from app.exceptions import NotFoundError
 from app.models.plan_models import PlanCreate, PlanStatus, PlanUpdate
 
 
@@ -179,8 +180,17 @@ async def test_update_plan_status_invalid_transition(test_plan_service):
 
 
 @pytest.mark.asyncio
+async def test_get_plan_not_found(test_plan_service):
+    """Test retrieving a non-existent plan raises NotFoundError."""
+    user_id = uuid4()
+
+    with pytest.raises(NotFoundError, match="not found"):
+        await test_plan_service.get_plan(user_id=user_id, plan_id=99999)
+
+
+@pytest.mark.asyncio
 async def test_delete_plan(test_plan_service):
-    """Test creating, deleting, then verifying get returns None."""
+    """Test creating, deleting, then verifying get raises NotFoundError."""
     user_id = uuid4()
 
     plan = await test_plan_service.create_plan(
@@ -191,8 +201,8 @@ async def test_delete_plan(test_plan_service):
     success = await test_plan_service.delete_plan(user_id=user_id, plan_id=plan.id)
     assert success is True
 
-    retrieved = await test_plan_service.get_plan(user_id=user_id, plan_id=plan.id)
-    assert retrieved is None
+    with pytest.raises(NotFoundError, match="not found"):
+        await test_plan_service.get_plan(user_id=user_id, plan_id=plan.id)
 
 
 @pytest.mark.asyncio
@@ -207,8 +217,8 @@ async def test_user_isolation(test_plan_service):
     )
 
     # user2 cannot get user1's plan
-    retrieved = await test_plan_service.get_plan(user_id=user2, plan_id=plan.id)
-    assert retrieved is None
+    with pytest.raises(NotFoundError, match="not found"):
+        await test_plan_service.get_plan(user_id=user2, plan_id=plan.id)
 
     # user2 list returns empty
     user2_plans = await test_plan_service.list_plans(user_id=user2)

--- a/tests/integration/test_project_service.py
+++ b/tests/integration/test_project_service.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pytest
 
+from app.exceptions import NotFoundError
 from app.models.project_models import (
     ProjectCreate,
     ProjectStatus,
@@ -105,9 +106,8 @@ async def test_get_project_not_found(test_project_service):
     """Test retrieving a non-existent project"""
     user_id = uuid4()
 
-    project = await test_project_service.get_project(user_id=user_id, project_id=99999)
-
-    assert project is None
+    with pytest.raises(NotFoundError, match="not found"):
+        await test_project_service.get_project(user_id=user_id, project_id=99999)
 
 
 @pytest.mark.asyncio
@@ -474,11 +474,10 @@ async def test_delete_project(test_project_service):
     assert success is True
 
     # Verify project no longer exists
-    deleted_project = await test_project_service.get_project(
-        user_id=user_id, project_id=created_project.id,
-    )
-
-    assert deleted_project is None
+    with pytest.raises(NotFoundError, match="not found"):
+        await test_project_service.get_project(
+            user_id=user_id, project_id=created_project.id,
+        )
 
 
 @pytest.mark.asyncio
@@ -511,11 +510,10 @@ async def test_project_user_isolation(test_project_service):
     )
 
     # User 2 tries to get user 1's project
-    retrieved_project = await test_project_service.get_project(
-        user_id=user2_id, project_id=user1_project.id,
-    )
-
-    assert retrieved_project is None
+    with pytest.raises(NotFoundError, match="not found"):
+        await test_project_service.get_project(
+            user_id=user2_id, project_id=user1_project.id,
+        )
 
     # User 2 lists projects - should not see user 1's project
     user2_projects = await test_project_service.list_projects(user_id=user2_id)

--- a/tests/integration/test_task_service.py
+++ b/tests/integration/test_task_service.py
@@ -10,6 +10,7 @@ from app.exceptions import (
     CyclicDependencyError,
     DependencyNotMetError,
     InvalidStateTransitionError,
+    NotFoundError,
 )
 from app.models.plan_models import (
     CriterionCreate,
@@ -558,6 +559,42 @@ async def test_plan_auto_completion(test_task_service):
 
 
 @pytest.mark.asyncio
+async def test_plan_auto_completion_missing_plan_silent(test_task_service, monkeypatch):
+    """D1: swallow NotFoundError if plan disappears during auto-completion."""
+    task_service, plan_service = test_task_service
+    user_id = uuid4()
+
+    plan = await _create_active_plan(plan_service, user_id)
+    task = await task_service.create_task(
+        user_id=user_id,
+        task_data=TaskCreate(title="Only task", plan_id=plan.id),
+    )
+
+    async def get_plan_missing(*_args, **_kwargs):
+        raise NotFoundError(f"Plan with id {plan.id} not found")
+
+    monkeypatch.setattr(plan_service, "get_plan", get_plan_missing)
+
+    await task_service.transition_task(
+        user_id=user_id, task_id=task.id, new_state=TaskState.DOING, expected_version=1,
+    )
+    # Completing the task triggers _check_plan_auto_completion; missing plan must not raise
+    await task_service.transition_task(
+        user_id=user_id, task_id=task.id, new_state=TaskState.DONE, expected_version=2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_task_not_found(test_task_service):
+    """Test retrieving a non-existent task raises NotFoundError."""
+    task_service, _plan_service = test_task_service
+    user_id = uuid4()
+
+    with pytest.raises(NotFoundError, match="not found"):
+        await task_service.get_task(user_id=user_id, task_id=99999)
+
+
+@pytest.mark.asyncio
 async def test_user_isolation(test_task_service):
     """Test that a task created by user1 is not visible to user2."""
     task_service, plan_service = test_task_service
@@ -572,8 +609,8 @@ async def test_user_isolation(test_task_service):
     )
 
     # user2 cannot get user1's task
-    retrieved = await task_service.get_task(user_id=user2, task_id=task.id)
-    assert retrieved is None
+    with pytest.raises(NotFoundError, match="not found"):
+        await task_service.get_task(user_id=user2, task_id=task.id)
 
     # user2 list for the same plan_id returns empty
     user2_tasks = await task_service.list_tasks(user_id=user2, plan_id=plan.id)


### PR DESCRIPTION
Fixes #47

`execute_forgetful_tool` returned `null` for missing project/plan/task IDs because the service getters returned `None` and the adapters passed that through. The direct `@mcp.tool` handlers already raised `NotFoundError`; this aligns the meta-tool path.

`get_project`, `get_plan`, and `get_task` now raise `NotFoundError` with the same message shape as the existing MCP tools. REST GET maps that to 404. `_check_plan_auto_completion` catches `NotFoundError` if the plan disappears mid-flow.

Integration tests, sqlite MCP e2e, and REST 404 tests included.
