### PR TITLE
fix: eager-load linking_memories in get_recent_memories

### DIFF
--- a/app/repositories/postgres/memory_repository.py
+++ b/app/repositories/postgres/memory_repository.py
@@ -736,6 +736,7 @@ class PostgresMemoryRepository:
             .options(
                 selectinload(MemoryTable.projects),
                 selectinload(MemoryTable.linked_memories),
+                selectinload(MemoryTable.linking_memories),
                 selectinload(MemoryTable.code_artifacts),
                 selectinload(MemoryTable.documents),
                 selectinload(MemoryTable.files),

--- a/app/repositories/sqlite/memory_repository.py
+++ b/app/repositories/sqlite/memory_repository.py
@@ -784,6 +784,7 @@ class SqliteMemoryRepository:
             .options(
                 selectinload(MemoryTable.projects),
                 selectinload(MemoryTable.linked_memories),
+                selectinload(MemoryTable.linking_memories),
                 selectinload(MemoryTable.code_artifacts),
                 selectinload(MemoryTable.documents),
                 selectinload(MemoryTable.files),

--- a/docs/tool_reference.md
+++ b/docs/tool_reference.md
@@ -371,6 +371,7 @@ Retrieve most recent memories sorted by creation timestamp.
 - An object (not a bare list) with two keys:
   - `memories`: list of recent memories, sorted by `created_at` DESC (newest first)
   - `total_count`: total number of matching memories
+- Each memory's `linked_memory_ids` includes both directions of links (same set as `get_memory`).
 
 **Example:**
 ```python

--- a/tests/e2e/test_memory_tools_e2e.py
+++ b/tests/e2e/test_memory_tools_e2e.py
@@ -598,6 +598,80 @@ async def test_get_recent_memories_basic_e2e(mcp_client):
 
 
 @pytest.mark.e2e
+async def test_get_recent_memories_linked_ids_match_get_memory_e2e(mcp_client):
+    """get_recent_memories linked_memory_ids must match get_memory for both link ends."""
+    import json
+
+    project_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_project", "arguments": {
+            "name": "recent-linked-ids-match-test-postgres",
+            "description": "Isolation for get_recent linked_memory_ids e2e",
+            "project_type": "development",
+        },
+    })
+    project_id = project_result.data["id"]
+
+    memory_a_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_memory", "arguments": {
+            "title": "Machine Learning Basics",
+            "content": "Machine learning is a subset of AI focused on pattern recognition",
+            "context": "Testing manual linking between dissimilar memories",
+            "keywords": ["machine-learning", "ai", "patterns"],
+            "tags": ["ml", "basics"],
+            "importance": 7,
+            "project_ids": [project_id],
+        },
+    })
+    memory_a_id = memory_a_result.data["id"]
+
+    memory_b_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_memory", "arguments": {
+            "title": "CSS Grid Layout",
+            "content": "CSS Grid provides a two-dimensional layout system for web design",
+            "context": "Testing manual linking - dissimilar to ML memory",
+            "keywords": ["css", "web", "layout"],
+            "tags": ["frontend", "css"],
+            "importance": 7,
+            "project_ids": [project_id],
+        },
+    })
+    memory_b_id = memory_b_result.data["id"]
+
+    await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "link_memories",
+        "arguments": {"memory_id": memory_a_id, "related_ids": [memory_b_id]},
+    })
+
+    get_a_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "get_memory", "arguments": {"memory_id": memory_a_id},
+    })
+    get_b_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "get_memory", "arguments": {"memory_id": memory_b_id},
+    })
+    assert memory_b_id in get_a_result.data["linked_memory_ids"]
+    assert memory_a_id in get_b_result.data["linked_memory_ids"]
+
+    recent_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "get_recent_memories", "arguments": {
+            "limit": 20,
+            "project_ids": [project_id],
+        },
+    })
+    envelope = json.loads(recent_result.content[0].text)
+    memories = envelope["memories"]
+    assert envelope["total_count"] >= len(memories)
+
+    recent_by_id = {m["id"]: m for m in memories}
+    recent_a = recent_by_id[memory_a_id]
+    recent_b = recent_by_id[memory_b_id]
+
+    assert set(recent_a["linked_memory_ids"]) == set(get_a_result.data["linked_memory_ids"])
+    assert set(recent_b["linked_memory_ids"]) == set(get_b_result.data["linked_memory_ids"])
+    assert memory_b_id in recent_a["linked_memory_ids"]
+    assert memory_a_id in recent_b["linked_memory_ids"]
+
+
+@pytest.mark.e2e
 async def test_get_recent_memories_with_project_filter_e2e(mcp_client):
     """Test getting recent memories filtered by project"""
     # Create a project

--- a/tests/e2e_sqlite/test_memory_tools_sqlite.py
+++ b/tests/e2e_sqlite/test_memory_tools_sqlite.py
@@ -583,6 +583,80 @@ async def test_get_recent_memories_basic_e2e(mcp_client):
 
 
 @pytest.mark.asyncio
+async def test_get_recent_memories_linked_ids_match_get_memory_e2e(mcp_client):
+    """get_recent_memories linked_memory_ids must match get_memory for both link ends."""
+    import json
+
+    project_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_project", "arguments": {
+            "name": "recent-linked-ids-match-test-sqlite",
+            "description": "Isolation for get_recent linked_memory_ids e2e",
+            "project_type": "development",
+        },
+    })
+    project_id = project_result.data["id"]
+
+    memory_a_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_memory", "arguments": {
+            "title": "Machine Learning Basics",
+            "content": "Machine learning is a subset of AI focused on pattern recognition",
+            "context": "Testing manual linking between dissimilar memories",
+            "keywords": ["machine-learning", "ai", "patterns"],
+            "tags": ["ml", "basics"],
+            "importance": 7,
+            "project_ids": [project_id],
+        },
+    })
+    memory_a_id = memory_a_result.data["id"]
+
+    memory_b_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_memory", "arguments": {
+            "title": "CSS Grid Layout",
+            "content": "CSS Grid provides a two-dimensional layout system for web design",
+            "context": "Testing manual linking - dissimilar to ML memory",
+            "keywords": ["css", "web", "layout"],
+            "tags": ["frontend", "css"],
+            "importance": 7,
+            "project_ids": [project_id],
+        },
+    })
+    memory_b_id = memory_b_result.data["id"]
+
+    await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "link_memories",
+        "arguments": {"memory_id": memory_a_id, "related_ids": [memory_b_id]},
+    })
+
+    get_a_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "get_memory", "arguments": {"memory_id": memory_a_id},
+    })
+    get_b_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "get_memory", "arguments": {"memory_id": memory_b_id},
+    })
+    assert memory_b_id in get_a_result.data["linked_memory_ids"]
+    assert memory_a_id in get_b_result.data["linked_memory_ids"]
+
+    recent_result = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "get_recent_memories", "arguments": {
+            "limit": 20,
+            "project_ids": [project_id],
+        },
+    })
+    envelope = json.loads(recent_result.content[0].text)
+    memories = envelope["memories"]
+    assert envelope["total_count"] >= len(memories)
+
+    recent_by_id = {m["id"]: m for m in memories}
+    recent_a = recent_by_id[memory_a_id]
+    recent_b = recent_by_id[memory_b_id]
+
+    assert set(recent_a["linked_memory_ids"]) == set(get_a_result.data["linked_memory_ids"])
+    assert set(recent_b["linked_memory_ids"]) == set(get_b_result.data["linked_memory_ids"])
+    assert memory_b_id in recent_a["linked_memory_ids"]
+    assert memory_a_id in recent_b["linked_memory_ids"]
+
+
+@pytest.mark.asyncio
 async def test_get_recent_memories_with_project_filter_e2e(mcp_client):
     """Test getting recent memories filtered by project"""
     # Create a project

--- a/tests/integration/test_memory_service.py
+++ b/tests/integration/test_memory_service.py
@@ -205,6 +205,55 @@ async def test_link_memories_bidirectional(test_memory_service):
 
 
 @pytest.mark.asyncio
+async def test_get_recent_memories_linked_ids_match_get_memory(test_memory_service):
+    """get_recent_memories linked_memory_ids must match get_memory for both link ends."""
+    user_id = uuid4()
+
+    memory1_data = MemoryCreate(
+        title="Python AsyncIO Event Loop",
+        content="AsyncIO provides event loop for asynchronous programming in Python",
+        context="Technical documentation about Python async features",
+        keywords=["python", "asyncio", "async"],
+        tags=["programming", "python"],
+        importance=7,
+    )
+    memory1, _ = await test_memory_service.create_memory(user_id, memory1_data)
+
+    memory2_data = MemoryCreate(
+        title="Database Connection Pooling",
+        content="Connection pooling improves database performance by reusing connections",
+        context="Database optimization technique",
+        keywords=["database", "pooling", "performance"],
+        tags=["database", "optimization"],
+        importance=7,
+    )
+    memory2, _ = await test_memory_service.create_memory(user_id, memory2_data)
+
+    await test_memory_service.link_memories(
+        user_id=user_id,
+        memory_id=memory1.id,
+        related_ids=[memory2.id],
+    )
+
+    get_a = await test_memory_service.get_memory(user_id, memory1.id)
+    get_b = await test_memory_service.get_memory(user_id, memory2.id)
+    assert memory2.id in get_a.linked_memory_ids
+    assert memory1.id in get_b.linked_memory_ids
+
+    recent, total = await test_memory_service.get_recent_memories(user_id=user_id, limit=10)
+    assert total >= 2
+
+    recent_by_id = {m.id: m for m in recent}
+    recent_a = recent_by_id[memory1.id]
+    recent_b = recent_by_id[memory2.id]
+
+    assert set(recent_a.linked_memory_ids) == set(get_a.linked_memory_ids)
+    assert set(recent_b.linked_memory_ids) == set(get_b.linked_memory_ids)
+    assert memory2.id in recent_a.linked_memory_ids
+    assert memory1.id in recent_b.linked_memory_ids
+
+
+@pytest.mark.asyncio
 async def test_update_memory_content(test_memory_service):
     """Test updating memory content"""
     user_id = uuid4()


### PR DESCRIPTION
Fixes #46.

### Problem
`get_memory` loads both `linked_memories` (where this memory is the source) and `linking_memories` (where this memory is the target). `get_recent_memories` only loaded `linked_memories`. Because links are stored as a single undirected row with `source_id = min(a, b)` and `target_id = max(a, b)`, the higher ID of a linked pair had an empty `linked_memory_ids` list when retrieved via `get_recent_memories`.

### Solution
Added `selectinload(MemoryTable.linking_memories)` to `get_recent_memories` in both SQLite and PostgreSQL repositories, matching what `get_memory` and `query_memory` already do.

### Testing
Added integration and E2E tests verifying that `linked_memory_ids` from `get_recent_memories` matches `get_memory` for both ends of a manual link.
