### PR TITLE
docs(memory): document access_count and last_accessed_at (#53)

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -114,7 +114,9 @@ List memories with pagination, sorting, and filtering.
       "source_url": "https://example.com/source",
       "confidence": 0.85,
       "encoding_agent": "claude-sonnet-4",
-      "encoding_version": "1.0.0"
+      "encoding_version": "1.0.0",
+      "access_count": 0,
+      "last_accessed_at": null
     }
   ],
   "total": 42,
@@ -128,6 +130,8 @@ List memories with pagination, sorting, and filtering.
 Get a single memory by ID.
 
 **Response:** Memory object (see above)
+
+The object includes server-managed `access_count` (int, default 0) and `last_accessed_at` (ISO datetime or null). Callers cannot set them on POST/PUT; incrementing them does not change `updated_at`. On upstream, counters increment only when `memory.read` / `memory.queried` events fire (`get_memory` / `query_memory`), which requires `ACTIVITY_TRACK_READS=true` and a wired EventBus (default off → counters stay 0). REST list (`get_recent_memories`) does not increment them.
 
 ### POST /api/v1/memories
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -796,6 +796,14 @@ Activity tracking provides an audit log of all entity lifecycle events (created,
 - **⚠️ Warning**: Enabling this can generate high event volume in active systems
 - **Example**: `ACTIVITY_TRACK_READS=false`
 
+Memory fields `access_count` and `last_accessed_at` are not activity-log rows.
+They live on the `Memory` model. On upstream they increment only when
+`memory.read` / `memory.queried` events fire (`get_memory` / `query_memory`),
+which requires `ACTIVITY_TRACK_READS=true` and a wired EventBus
+(default `ACTIVITY_TRACK_READS=false` → counters stay 0).
+REST list (`get_recent_memories`) does not emit those events.
+`ACTIVITY_TRACK_READS` still also controls activity-log *events*.
+
 ### SSE Streaming Configuration
 
 #### `SSE_MAX_QUEUE_SIZE`

--- a/docs/tool_reference.md
+++ b/docs/tool_reference.md
@@ -231,6 +231,7 @@ Semantic search across all memories with context-aware ranking.
 **Returns:**
 - List of memories ranked by semantic relevance
 - Each memory includes linked artifacts and 1-hop graph connections
+- `access_count` / `last_accessed_at` on each returned **full** `Memory` (not on `MemorySummary`). On upstream they increment when `memory.queried` fires, which requires `ACTIVITY_TRACK_READS=true` and an EventBus. Not request parameters.
 
 **Example:**
 ```python
@@ -256,6 +257,7 @@ Retrieve complete memory details by ID.
 
 **Returns:**
 - Complete memory object with all fields and relationships
+- `access_count` / `last_accessed_at` on the **full** `Memory`. On upstream they increment when `memory.read` fires, which requires `ACTIVITY_TRACK_READS=true` and an EventBus. Not writable via `update_memory`.
 
 **Example:**
 ```python


### PR DESCRIPTION
## Summary

Docs-only change documenting `access_count` and `last_accessed_at` telemetry fields introduced in #53.

- Counters increment on full `Memory` reads via the EventBus, gated by `ACTIVITY_TRACK_READS`.
- REST list endpoints do not increment access counters.

Closes the documentation gap left by merged #53.
