### PR TITLE
fix(mcp): tolerate common parameter aliases in memory tool adapters

### DIFF
--- a/app/routes/mcp/memory_tools.py
+++ b/app/routes/mcp/memory_tools.py
@@ -421,6 +421,11 @@ def register(mcp: FastMCP):
             List of target memory IDs that were successfully linked
         """
         try:
+            if isinstance(related_ids, (int, str)):
+                related_ids = [int(related_ids)]
+            elif isinstance(related_ids, (list, tuple, set)):
+                related_ids = [int(x) for x in related_ids]
+
             logger.info("MCP Tool -> link_memories", extra={
                 "memory_id": memory_id,
                 "related_ids": related_ids,
@@ -431,7 +436,7 @@ def register(mcp: FastMCP):
             if not related_ids:
                 raise ToolError("related_ids cannot be empty")
 
-            related_ids = [rid for rid in related_ids if rid !=memory_id]
+            related_ids = [rid for rid in dict.fromkeys(related_ids) if rid != memory_id]
 
             if not related_ids:
                 raise ToolError("Cannot link memory to itself")

--- a/app/routes/mcp/tool_adapters.py
+++ b/app/routes/mcp/tool_adapters.py
@@ -284,8 +284,9 @@ class MemoryToolAdapters:
 
     async def update_memory(
         self,
-        memory_id: int,
         ctx: Context,
+        memory_id: int | None = None,
+        id: int | None = None,
         title: str | None = None,
         content: str | None = None,
         context: str | None = None,
@@ -305,9 +306,14 @@ class MemoryToolAdapters:
         agent_id: str | None = None,
         agent_version: str | None = None,
         agent_model: str | None = None,
+        **kwargs,
     ) -> Memory:
         """Adapter for update_memory tool"""
-        logger.info("MCP Tool -> update_memory", extra={"memory_id": memory_id})
+        mid = memory_id if memory_id is not None else id
+        if mid is None:
+            raise ValueError("update_memory requires memory_id (or id)")
+        mid = int(mid)
+        logger.info("MCP Tool -> update_memory", extra={"memory_id": mid})
 
         user = await get_user_from_auth(ctx)
 
@@ -339,7 +345,7 @@ class MemoryToolAdapters:
 
         refreshed_memory = await self.memory_service.update_memory(
             user_id=user.id,
-            memory_id=memory_id,
+            memory_id=mid,
             updated_memory=updated_memory,
         )
 
@@ -347,78 +353,223 @@ class MemoryToolAdapters:
 
     async def link_memories(
         self,
-        memory_id: int,
-        related_ids: list[int],
         ctx: Context,
+        memory_id: int | None = None,
+        related_ids: list[int] | int | None = None,
+        source_id: int | None = None,
+        target_id: int | None = None,
+        target_ids: list[int] | int | None = None,
+        related_id: int | None = None,
+        memory_id_1: int | None = None,
+        memory_id_2: int | None = None,
+        from_id: int | None = None,
+        to_id: int | None = None,
+        from_memory_id: int | None = None,
+        to_memory_id: int | None = None,
+        memory_ids: list[int] | None = None,
+        ids: list[int] | None = None,
+        id: int | None = None,
+        linked_ids: list[int] | int | None = None,
+        related_memory_ids: list[int] | int | None = None,
+        **kwargs,
     ) -> dict:
-        """Adapter for link_memories tool"""
+        """Adapter for link_memories tool with alias resilience"""
+        src: int | None = None
+        targets: list[int] = []
+
+        if memory_ids and len(memory_ids) >= 2:
+            src = int(memory_ids[0])
+            targets = [int(x) for x in memory_ids[1:]]
+        elif ids and len(ids) >= 2:
+            src = int(ids[0])
+            targets = [int(x) for x in ids[1:]]
+        else:
+            raw_src = memory_id if memory_id is not None else (
+                source_id if source_id is not None else (
+                    from_id if from_id is not None else (
+                        from_memory_id if from_memory_id is not None else (
+                            memory_id_1 if memory_id_1 is not None else id
+                        )
+                    )
+                )
+            )
+            if raw_src is not None:
+                src = int(raw_src)
+
+            raw_targets = (
+                related_ids
+                if related_ids is not None
+                else (
+                    target_ids
+                    if target_ids is not None
+                    else (
+                        target_id
+                        if target_id is not None
+                        else (
+                            related_id
+                            if related_id is not None
+                            else (
+                                to_id
+                                if to_id is not None
+                                else (
+                                    to_memory_id
+                                    if to_memory_id is not None
+                                    else (
+                                        memory_id_2
+                                        if memory_id_2 is not None
+                                        else (
+                                            linked_ids
+                                            if linked_ids is not None
+                                            else related_memory_ids
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            if raw_targets is not None:
+                if isinstance(raw_targets, (list, tuple, set)):
+                    targets = [int(x) for x in raw_targets]
+                else:
+                    targets = [int(raw_targets)]
+
+        if src is None:
+            raise ValueError("link_memories requires memory_id (or source_id)")
+        if not targets:
+            raise ValueError("related_ids cannot be empty")
+
+        cleaned_related_ids = [rid for rid in dict.fromkeys(targets) if rid != src]
+
+        if not cleaned_related_ids:
+            raise ValueError("Cannot link memory to itself")
+
         logger.info(
             "MCP Tool -> link_memories",
-            extra={"memory_id": memory_id, "related_ids": related_ids},
+            extra={"memory_id": src, "related_ids": cleaned_related_ids},
         )
 
         user = await get_user_from_auth(ctx)
 
-        if not related_ids:
-            raise ValueError("related_ids cannot be empty")
-
-        related_ids = [rid for rid in related_ids if rid != memory_id]
-
-        if not related_ids:
-            raise ValueError("Cannot link memory to itself")
-
         links_created = await self.memory_service.link_memories(
             user_id=user.id,
-            memory_id=memory_id,
-            related_ids=related_ids,
+            memory_id=src,
+            related_ids=cleaned_related_ids,
         )
 
         logger.info(
             "MCP Tool - memories linked",
-            extra={"memory_id": memory_id, "memories_linked": links_created},
+            extra={"memory_id": src, "memories_linked": links_created},
         )
 
         return {"linked_memory_ids": links_created}
 
     async def unlink_memories(
         self,
-        source_id: int,
-        target_id: int,
         ctx: Context,
+        source_id: int | None = None,
+        target_id: int | None = None,
+        memory_id: int | None = None,
+        related_id: int | None = None,
+        related_ids: list[int] | int | None = None,
+        target_ids: list[int] | int | None = None,
+        memory_ids: list[int] | None = None,
+        ids: list[int] | None = None,
+        memory_id_1: int | None = None,
+        memory_id_2: int | None = None,
+        from_id: int | None = None,
+        to_id: int | None = None,
+        from_memory_id: int | None = None,
+        to_memory_id: int | None = None,
+        id: int | None = None,
+        **kwargs,
     ) -> dict:
-        """Adapter for unlink_memories tool"""
+        """Adapter for unlink_memories tool with alias resilience"""
+        src: int | None = None
+        tgt: int | None = None
+
+        if memory_ids and len(memory_ids) >= 2:
+            src = int(memory_ids[0])
+            tgt = int(memory_ids[1])
+        elif ids and len(ids) >= 2:
+            src = int(ids[0])
+            tgt = int(ids[1])
+        else:
+            raw_src = source_id if source_id is not None else (
+                memory_id if memory_id is not None else (
+                    from_id if from_id is not None else (
+                        from_memory_id if from_memory_id is not None else (
+                            memory_id_1 if memory_id_1 is not None else id
+                        )
+                    )
+                )
+            )
+            if raw_src is not None:
+                src = int(raw_src)
+
+            raw_tgt = target_id if target_id is not None else (
+                related_id if related_id is not None else (
+                    to_id if to_id is not None else (
+                        to_memory_id if to_memory_id is not None else (
+                            memory_id_2 if memory_id_2 is not None else (
+                                (related_ids[0] if isinstance(related_ids, (list, tuple, set)) and related_ids else (related_ids if isinstance(related_ids, int) else None))
+                                if related_ids is not None
+                                else (
+                                    (target_ids[0] if isinstance(target_ids, (list, tuple, set)) and target_ids else (target_ids if isinstance(target_ids, int) else None))
+                                    if target_ids is not None
+                                    else None
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+            if raw_tgt is not None:
+                tgt = int(raw_tgt)
+
+        if src is None or tgt is None:
+            raise ValueError("unlink_memories requires source_id (or memory_id) and target_id (or related_id)")
+
         logger.info(
             "MCP Tool -> unlink_memories",
-            extra={"source_id": source_id, "target_id": target_id},
+            extra={"source_id": src, "target_id": tgt},
         )
 
         user = await get_user_from_auth(ctx)
 
         success = await self.memory_service.unlink_memories(
             user_id=user.id,
-            memory_id=source_id,
-            target_id=target_id,
+            memory_id=src,
+            target_id=tgt,
         )
 
         logger.info(
             "MCP Tool - memories unlinked",
-            extra={"source_id": source_id, "target_id": target_id, "success": success},
+            extra={"source_id": src, "target_id": tgt, "success": success},
         )
 
         return {"success": success}
 
     async def get_memory(
         self,
-        memory_id: int,
         ctx: Context,
+        memory_id: int | None = None,
+        id: int | None = None,
+        **kwargs,
     ) -> Memory:
         """Adapter for get_memory tool"""
-        logger.info("MCP Tool -> get_memory", extra={"memory_id": memory_id})
+        mid = memory_id if memory_id is not None else id
+        if mid is None:
+            raise ValueError("get_memory requires memory_id (or id)")
+        mid = int(mid)
+        logger.info("MCP Tool -> get_memory", extra={"memory_id": mid})
 
         user = await get_user_from_auth(ctx)
 
         memory = await self.memory_service.get_memory(
-            user_id=user.id, memory_id=memory_id,
+            user_id=user.id, memory_id=mid,
         )
 
         logger.info(
@@ -430,19 +581,26 @@ class MemoryToolAdapters:
 
     async def mark_memory_obsolete(
         self,
-        memory_id: int,
-        reason: str,
         ctx: Context,
+        memory_id: int | None = None,
+        id: int | None = None,
+        *,
+        reason: str,
         superseded_by: int | None = None,
+        **kwargs,
     ) -> dict:
         """Adapter for mark_memory_obsolete tool"""
-        logger.info("MCP Tool -> mark_memory_obsolete", extra={"memory_id": memory_id})
+        mid = memory_id if memory_id is not None else id
+        if mid is None:
+            raise ValueError("mark_memory_obsolete requires memory_id (or id)")
+        mid = int(mid)
+        logger.info("MCP Tool -> mark_memory_obsolete", extra={"memory_id": mid})
 
         user = await get_user_from_auth(ctx)
 
         success = await self.memory_service.mark_memory_obsolete(
             user_id=user.id,
-            memory_id=memory_id,
+            memory_id=mid,
             reason=reason,
             superseded_by=superseded_by,
         )

--- a/app/routes/mcp/tool_metadata_registry.py
+++ b/app/routes/mcp/tool_metadata_registry.py
@@ -563,19 +563,19 @@ def register_memory_tools_metadata(
         {
             "name": "link_memories",
             "mutates": True,
-            "description": "Manually create bidirectional links between memories (symmetric linking)",
+            "description": "Manually create bidirectional links between memories (symmetric linking). Accepts memory_id + related_ids (or aliases source_id + target_id/target_ids, memory_ids=[src, tgt])",
             "parameters": [
                 {
                     "name": "memory_id",
                     "type": "int",
-                    "description": "Source memory ID",
+                    "description": "Source memory ID (aliases: source_id, from_id, id)",
                     "required": True,
                     "example": 42,
                 },
                 {
                     "name": "related_ids",
                     "type": "List[int]",
-                    "description": "List of target memory IDs to link",
+                    "description": "List of target memory IDs to link (or single int; aliases: target_id, target_ids, related_id)",
                     "required": True,
                     "example": [10, 15, 20],
                 },
@@ -589,25 +589,27 @@ def register_memory_tools_metadata(
             "returns": "List of memory IDs that were successfully linked",
             "examples": [
                 'execute_forgetful_tool("link_memories", {"memory_id": 42, "related_ids": [10, 15, 20]})',
+                'execute_forgetful_tool("link_memories", {"source_id": 42, "target_id": 57})',
+                'execute_forgetful_tool("link_memories", {"memory_ids": [42, 57]})',
             ],
             "tags": ["memory", "linking", "relationships"],
         },
         {
             "name": "unlink_memories",
             "mutates": True,
-            "description": "Remove a bidirectional link between two memories",
+            "description": "Remove a bidirectional link between two memories. Accepts source_id + target_id (or aliases memory_id + related_id, memory_ids=[src, tgt])",
             "parameters": [
                 {
                     "name": "source_id",
                     "type": "int",
-                    "description": "Source memory ID",
+                    "description": "Source memory ID (aliases: memory_id, from_id, id)",
                     "required": True,
                     "example": 42,
                 },
                 {
                     "name": "target_id",
                     "type": "int",
-                    "description": "Target memory ID to unlink",
+                    "description": "Target memory ID to unlink (aliases: related_id, to_id)",
                     "required": True,
                     "example": 57,
                 },
@@ -621,6 +623,7 @@ def register_memory_tools_metadata(
             "returns": "Dict with 'success' boolean (True if link was removed, False if link didn't exist)",
             "examples": [
                 'execute_forgetful_tool("unlink_memories", {"source_id": 42, "target_id": 57})',
+                'execute_forgetful_tool("unlink_memories", {"memory_id": 42, "related_id": 57})',
             ],
             "tags": ["memory", "unlink", "graph", "linking"],
         },

--- a/docs/tool_reference.md
+++ b/docs/tool_reference.md
@@ -319,20 +319,69 @@ execute_forgetful_tool(
 Manually create bidirectional links between memories.
 
 **Parameters:**
-- `memory_id` (required): Source memory ID
-- `related_ids` (required): Target memory IDs
+- `memory_id` (required, int): Source memory ID (aliases: `source_id`, `from_id`, `id`)
+- `related_ids` (required, List[int] or int): Target memory IDs (aliases: `target_id`, `target_ids`, `related_id`, `linked_ids`)
+- `memory_ids` (optional, List[int]): Pair/list of memory IDs `[src, target1, target2, ...]`
 
 **Returns:**
-- Confirmation of link creation
+- Dict with `linked_memory_ids` (list of target IDs newly linked)
 
-**Example:**
+**Examples:**
 ```python
-# Link related architecture decisions
+# Standard syntax
 execute_forgetful_tool(
     "link_memories",
     {
         "memory_id": 156,  # Rate limiting decision
         "related_ids": [201]  # Redis caching strategy
+    }
+)
+
+# Alias syntax with source_id and target_id
+execute_forgetful_tool(
+    "link_memories",
+    {
+        "source_id": 156,
+        "target_id": 201
+    }
+)
+
+# Pair list syntax
+execute_forgetful_tool(
+    "link_memories",
+    {
+        "memory_ids": [156, 201]
+    }
+)
+```
+
+### `unlink_memories`
+
+Remove a bidirectional link between two memories.
+
+**Parameters:**
+- `source_id` (required, int): Source memory ID (aliases: `memory_id`, `from_id`, `id`)
+- `target_id` (required, int): Target memory ID (aliases: `related_id`, `to_id`)
+- `memory_ids` (optional, List[int]): Pair of memory IDs `[src, target]`
+
+**Returns:**
+- Dict with `success` boolean
+
+**Examples:**
+```python
+execute_forgetful_tool(
+    "unlink_memories",
+    {
+        "source_id": 156,
+        "target_id": 201
+    }
+)
+
+execute_forgetful_tool(
+    "unlink_memories",
+    {
+        "memory_id": 156,
+        "related_id": 201
     }
 )
 ```

--- a/tests/e2e_sqlite/test_link_memories_no_autolink_sqlite.py
+++ b/tests/e2e_sqlite/test_link_memories_no_autolink_sqlite.py
@@ -295,3 +295,136 @@ async def test_link_memories_invalid_source_id_e2e(mcp_client):
         error_message = str(e)
         assert "not found" in error_message.lower(
             ) or "validation_error" in error_message.lower()
+
+
+@pytest.mark.asyncio
+async def test_link_memories_aliases_e2e(mcp_client):
+    """Test all alias variations for link_memories and unlink_memories (FF-29)."""
+    # Create 4 memories
+    m1_res = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_memory",
+        "arguments": {
+            "title": "Alias Test Memory 1",
+            "content": "First memory for testing parameter aliases",
+            "context": "Testing FF-29 parameter resilience",
+            "keywords": ["test", "alias", "m1"],
+            "tags": ["test"],
+            "importance": 7,
+        },
+    })
+    m1_id = m1_res.data["id"]
+
+    m2_res = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_memory",
+        "arguments": {
+            "title": "Alias Test Memory 2",
+            "content": "Second memory for testing parameter aliases",
+            "context": "Testing FF-29 parameter resilience",
+            "keywords": ["test", "alias", "m2"],
+            "tags": ["test"],
+            "importance": 7,
+        },
+    })
+    m2_id = m2_res.data["id"]
+
+    m3_res = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_memory",
+        "arguments": {
+            "title": "Alias Test Memory 3",
+            "content": "Third memory for testing parameter aliases",
+            "context": "Testing FF-29 parameter resilience",
+            "keywords": ["test", "alias", "m3"],
+            "tags": ["test"],
+            "importance": 7,
+        },
+    })
+    m3_id = m3_res.data["id"]
+
+    m4_res = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "create_memory",
+        "arguments": {
+            "title": "Alias Test Memory 4",
+            "content": "Fourth memory for testing parameter aliases",
+            "context": "Testing FF-29 parameter resilience",
+            "keywords": ["test", "alias", "m4"],
+            "tags": ["test"],
+            "importance": 7,
+        },
+    })
+    m4_id = m4_res.data["id"]
+
+    # 1. Test source_id + target_id (scalar int)
+    link1 = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "link_memories",
+        "arguments": {"source_id": m1_id, "target_id": m2_id},
+    })
+    assert link1.data is not None
+    assert m2_id in link1.data["linked_memory_ids"]
+
+    # 2. Test memory_id + related_id (scalar int)
+    link2 = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "link_memories",
+        "arguments": {"memory_id": m1_id, "related_id": m3_id},
+    })
+    assert link2.data is not None
+    assert m3_id in link2.data["linked_memory_ids"]
+
+    # 3. Test memory_ids list [src, tgt]
+    link3 = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "link_memories",
+        "arguments": {"memory_ids": [m1_id, m4_id]},
+    })
+    assert link3.data is not None
+    assert m4_id in link3.data["linked_memory_ids"]
+
+    # 4. Test source_id + target_ids list
+    link4 = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "link_memories",
+        "arguments": {"source_id": m2_id, "target_ids": [m3_id, m4_id]},
+    })
+    assert link4.data is not None
+    assert set(link4.data["linked_memory_ids"]) == {m3_id, m4_id}
+
+    # Verify links via get_memory using "id" alias
+    get_m1 = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "get_memory",
+        "arguments": {"id": m1_id},
+    })
+    assert get_m1.data is not None
+    assert m2_id in get_m1.data["linked_memory_ids"]
+    assert m3_id in get_m1.data["linked_memory_ids"]
+    assert m4_id in get_m1.data["linked_memory_ids"]
+
+    # Test update_memory using "id" alias
+    up_m1 = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "update_memory",
+        "arguments": {"id": m1_id, "content": "Updated content via id alias"},
+    })
+    assert up_m1.data is not None
+    assert up_m1.data["content"] == "Updated content via id alias"
+
+    # Test unlink_memories using memory_id + related_id
+    unlink1 = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "unlink_memories",
+        "arguments": {"memory_id": m1_id, "related_id": m2_id},
+    })
+    assert unlink1.data is not None
+    assert unlink1.data["success"] is True
+
+    # Test unlink_memories using memory_ids list
+    unlink2 = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "unlink_memories",
+        "arguments": {"memory_ids": [m1_id, m3_id]},
+    })
+    assert unlink2.data is not None
+    assert unlink2.data["success"] is True
+
+    # Verify unlinking on m1
+    get_m1_after = await mcp_client.call_tool("execute_forgetful_tool", {
+        "tool_name": "get_memory",
+        "arguments": {"memory_id": m1_id},
+    })
+    assert m2_id not in get_m1_after.data["linked_memory_ids"]
+    assert m3_id not in get_m1_after.data["linked_memory_ids"]
+    assert m4_id in get_m1_after.data["linked_memory_ids"]
+


### PR DESCRIPTION
## Summary

LLM clients calling execute_forgetful_tool regularly guess the parameter names when linking memories. Instead of memory_id plus related_ids they send source_id and target_id, or a bare integer where a list is expected, or a two-element memory_ids pair. Every one of those raises TypeError: unexpected keyword argument inside MemoryToolAdapters, and since the client usually does not retry, the link is just lost. I hit this twice in normal usage before deciding to fix it.

I normalized the common aliases in MemoryToolAdapters for link_memories, unlink_memories, update_memory, get_memory and mark_memory_obsolete. A scalar related_ids is coerced to a one-element list, duplicates are dropped, and a memory linking to itself is rejected instead of reaching the service layer. Unknown keyword arguments on the adapter path are absorbed rather than raising, so a client inventing an extra key does not fail the whole call. Required fields stay required.

The direct @mcp.tool registrations in memory_tools.py keep their strict signatures. Only the execute_forgetful_tool adapter layer gets the full alias handling, plus one small scalar coercion in link_memories itself. That asymmetry is deliberate: the decorated tools are a published schema and I did not want to widen it, while the adapter layer is where the loose calls actually arrive. Tool metadata and docs/tool_reference.md document what is accepted.

## Test plan

- [x] `pytest tests/e2e_sqlite/test_link_memories_no_autolink_sqlite.py -v` (7 passed, including new alias coverage)
- [x] `pytest tests/e2e_sqlite/test_memory_tools_sqlite.py tests/integration/test_tool_registry.py -v` (64 passed)
